### PR TITLE
Fixed typos in original language files

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -7,12 +7,12 @@
         <item>Droplets</item>
         <item>Domains</item>
         <item>Images</item>
-        <item>SSH Keys</item>
+        <item>SSH keys</item>
         <item>Regions</item>
         <item>Sizes</item>
     </string-array>
     <string-array name="pref_sync_frequency_entries">
-        <item name="0">Never (Update maually)</item>
+        <item name="0">Never (Update manually)</item>
         <item name="1">Every minute</item>
         <item name="30">Every 30 minutes</item>
         <item name="60">Every hour</item>
@@ -28,10 +28,10 @@
         <item name="1440">1440</item>
     </string-array>
 
-    <string name="pref_sync_frequency_key_label">Synchronization interval</string>
-    <string name="summary_sync_frequency">Frequency of synchronization</string>
+    <string name="pref_sync_frequency_key_label">Synchronisation interval</string>
+    <string name="summary_sync_frequency">Frequency of synchronisation</string>
     <string name="not_yet_implemented">Not yet implemented</string>
-    <string name="no_ssh_client">No ssh client found! Please install one to get this feature.</string>
+    <string name="no_ssh_client">No SSH client found! Please install one to get this feature.</string>
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>
     <string name="no_images">No images!</string>
@@ -52,7 +52,7 @@
     <string name="backups_active_label">Backups:</string>
     <string name="virtio_active_label">VirtIO:</string>
     <string name="private_networking_active_label">Private networking:</string>
-    <string name="ipv6_active_label">IP v6:</string>
+    <string name="ipv6_active_label">IPv6:</string>
     <string name="locked_label">Locked:</string>
     <string name="created_at_label">Created at:</string>
     <string name="memory_label">Memory:</string>
@@ -83,7 +83,7 @@
     <string name="disable_backups">Disable backups</string>
     <string name="rename">Rename</string>
     <string name="destroy">Destroy</string>
-    <string name="sync">Synchronize</string>
+    <string name="sync">Synchronise</string>
     <string name="settings">Settings</string>
     <string name="synchronising">Synchronising</string>
     <string name="synchronising_keys">Synchronising keys</string>
@@ -98,7 +98,7 @@
     <string name="synchronising_sizes_completed">Synchronising sizes completed</string>
     <string name="synchronising_regions">Synchronising regions</string>
     <string name="synchronising_regions_completed">Synchronising regions completed</string>
-    <string name="access_denied_message">Access denied! Please make sure your client id and api key are correct.</string>
+    <string name="access_denied_message">Access denied! Please make sure your Client ID and API key are correct.</string>
     <string name="action_add_droplet">Add droplet</string>
     <string name="action_add_domain">Add domain</string>
     <string name="action_add_record">Add record</string>
@@ -108,7 +108,7 @@
     <string name="select_image_label">Select image:</string>
     <string name="select_region_label">Select region:</string>
     <string name="select_droplet_label">Select droplet:</string>
-    <string name="ssh_keys_label">SSH Keys:</string>
+    <string name="ssh_keys_label">SSH keys:</string>
     <string name="private_networking_label">Private networking</string>
     <string name="domain_name_label">Domain name</string>
     <string name="create_droplet">Create droplet</string>
@@ -141,15 +141,15 @@
     <string name="title_rebuild_droplet">Rebuild droplet</string>
     <string name="summary_client_id">Client ID</string>
     <string name="client_id_label">Client ID</string>
-    <string name="summary_api_key">API Key</string>
-    <string name="api_key_label">API Key</string>
-    <string name="summary_token">Token used to authenicate the API requests</string>
+    <string name="summary_api_key">API key</string>
+    <string name="api_key_label">API key</string>
+    <string name="summary_token">Token used to authenticate the API requests</string>
     <string name="summary_account_name">Account name</string>
     <string name="account_name_label">Account name</string>
-    <string name="api_settings_title">API Settings</string>
+    <string name="api_settings_title">API settings</string>
     <string name="preferences_title">Preferences</string>
     <string name="records">Records</string>
-    <string name="scrub_data">Scrub Data</string>
+    <string name="scrub_data">Scrub data</string>
     <string name="ip_address_label">IP Address:</string>
     <string name="name_label">Name:</string>
     <string name="priority_label">Priority:</string>
@@ -159,7 +159,7 @@
     <string name="create_record">Create record</string>
     <string name="edit_record">Edit record</string>
     <string name="edit_ssh_key">Edit SSH key</string>
-    <string name="saving_ssh_key">Saving SSH Key</string>
+    <string name="saving_ssh_key">Saving SSH key</string>
     <string name="add_existing_account">Add existing account</string>
     <string name="create_new_account">Create new account</string>
     <string name="switch_account">Switch account</string>
@@ -175,7 +175,7 @@
 
     <!-- Optional button to Skip a PreferenceActivity [CHAR LIMIT=20] -->
     <string name="skip_button_label">Skip</string>
-    <string name="public_ssh_key_label">Public SSH Key:</string>
+    <string name="public_ssh_key_label">Public SSH key:</string>
     <string name="title_activity_add_account">AddAccountActivity</string>
     <string name="token_label">Token</string>
 


### PR DESCRIPTION
Adjusted casing for several strings.
Made the use of "synchronisation" vs. "synchronization" consistent,
always using "synchroisation" now.
